### PR TITLE
Apply psm changes

### DIFF
--- a/common/power.h
+++ b/common/power.h
@@ -1,13 +1,15 @@
 #ifndef _SWITCHIDENT_POWER_H_
 #define _SWITCHIDENT_POWER_H_
 
+Result powerInitialize(void);
+void powerExit(void);
 u32 SwitchIdent_GetBatteryPercent(void);
 char *SwitchIdent_GetChargerType(void);
 bool SwitchIdent_IsCharging(void);
-bool SwitchIdent_IsChargingEnabled(Service *srv);
-char *SwitchIdent_GetVoltageState(Service *srv);
-u64 SwitchIdent_GetRawBatteryChargePercentage(Service *srv);
-bool SwitchIdent_IsEnoughPowerSupplied(Service *srv);
-u64 SwitchIdent_GetBatteryAgePercent(Service *srv);
+bool SwitchIdent_IsChargingEnabled(void);
+char *SwitchIdent_GetVoltageState(void);
+u64 SwitchIdent_GetRawBatteryChargePercentage(void);
+bool SwitchIdent_IsEnoughPowerSupplied(void);
+u64 SwitchIdent_GetBatteryAgePercent(void);
 
 #endif

--- a/console/source/main.c
+++ b/console/source/main.c
@@ -11,7 +11,7 @@
 #include "utils.h"
 #include "wlan.h"
 
-static Service psm_service, wlaninf_service;
+static Service wlaninf_service;
 static bool isSDInserted = false, isGameCardInserted = false;
 
 static void SwitchIdent_InitServices(void) {
@@ -41,14 +41,11 @@ static void SwitchIdent_InitServices(void) {
 	if (R_FAILED(ret = nsInitialize()))
 		printf("nsInitialize() failed: 0x%x.\n\n", ret);
 
-	if (R_FAILED(ret = psmInitialize()))
-		printf("psmInitialize() failed: 0x%x.\n\n", ret);
+	if (R_FAILED(ret = powerInitialize()))
+		printf("powerInitialize() failed: 0x%x.\n\n", ret);
 
 	if (R_FAILED(ret = pcvInitialize()))
 		printf("pcvInitialize() failed: 0x%x.\n\n", ret);
-
-	if (R_FAILED(ret = smGetService(&psm_service, "psm")))
-		printf("psmInitialize() failed: 0x%x.\n\n", ret);
 
 	if (R_FAILED(ret = smGetService(&wlaninf_service, "wlan:inf")))
 		printf("wlaninfInitialize() failed: 0x%x.\n\n", ret);
@@ -65,9 +62,8 @@ static void SwitchIdent_InitServices(void) {
 
 static void SwitchIdent_TermServices(void) {
 	serviceClose(&wlaninf_service);
-	serviceClose(&psm_service);
 	pcvExit();
-	psmExit();
+	powerExit();
 	nsExit();
 	apmExit();
 	appletExit();
@@ -160,10 +156,10 @@ int main(int argc, char **argv) {
 		*/
 		printf("\x1b[15;0H");
 		printf("\x1b[94;1m*\x1b[0m Battery percentage:  \x1b[94;1m%lu %%\x1b[0m (\x1b[94;1m%s\x1b[0m) \x1b[0m          \n", SwitchIdent_GetBatteryPercent(), SwitchIdent_IsCharging()? "charging" : "not charging");
-		printf("\x1b[94;1m*\x1b[0m Battery voltage state: \x1b[94;1m%s          \n", SwitchIdent_GetVoltageState(&psm_service));
+		printf("\x1b[94;1m*\x1b[0m Battery voltage state: \x1b[94;1m%s          \n", SwitchIdent_GetVoltageState());
 		printf("\x1b[94;1m*\x1b[0m Battery charger type: \x1b[94;1m%s          \n", SwitchIdent_GetChargerType());
-		printf("\x1b[94;1m*\x1b[0m Battery charging enabled: \x1b[94;1m%s          \n", SwitchIdent_IsChargingEnabled(&psm_service)? "Yes" : "No");
-		printf("\x1b[94;1m*\x1b[0m Battery ample power supplied: \x1b[94;1m%s          \n\n", SwitchIdent_IsEnoughPowerSupplied(&psm_service)? "Yes" : "No");
+		printf("\x1b[94;1m*\x1b[0m Battery charging enabled: \x1b[94;1m%s          \n", SwitchIdent_IsChargingEnabled()? "Yes" : "No");
+		printf("\x1b[94;1m*\x1b[0m Battery ample power supplied: \x1b[94;1m%s          \n\n", SwitchIdent_IsEnoughPowerSupplied()? "Yes" : "No");
 
 		printf("\x1b[27;0H");
 		printf("\x1b[36;1m*\x1b[0m State: \x1b[36;1m%s          \n", SwitchIdent_GetOperationMode());

--- a/gui/source/main.c
+++ b/gui/source/main.c
@@ -1,11 +1,12 @@
 #include <switch.h>
 
 #include "menus.h"
+#include "power.h"
 #include "SDL_helper.h"
 
 static void Term_Services(void) {
 	pcvExit();
-	psmExit();
+	powerExit();
 	nsExit();
 	apmExit();
 	appletExit();
@@ -55,8 +56,8 @@ static void Init_Services(void) {
 	if (R_FAILED(ret = nsInitialize()))
 		printf("nsInitialize() failed: 0x%x.\n\n", ret);
 
-	if (R_FAILED(ret = psmInitialize()))
-		printf("psmInitialize() failed: 0x%x.\n\n", ret);
+	if (R_FAILED(ret = powerInitialize()))
+		printf("powerInitialize() failed: 0x%x.\n\n", ret);
 
 	if (R_FAILED(ret = pcvInitialize()))
 		printf("pcvInitialize() failed: 0x%x.\n\n", ret);

--- a/gui/source/menus.c
+++ b/gui/source/menus.c
@@ -15,7 +15,7 @@
 #define MAX_MENU_ITEMS 5
 
 static u32 item_height = 0;
-static Service setcal_service, psm_service, wlaninf_service;
+static Service setcal_service, wlaninf_service;
 static bool isSDInserted = false, isGameCardInserted = false;
 
 static void Menu_DrawItem(int x, int y, char *item_title, const char *text, ...) {
@@ -52,10 +52,10 @@ static void Menu_System(void) {
 
 static void Menu_Power(void) {
 	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 50, "Battery percentage:",  "%lu %% (%s)", SwitchIdent_GetBatteryPercent(), SwitchIdent_IsCharging()? "charging" : "not charging");
-	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 100, "Battery voltage state:", SwitchIdent_GetVoltageState(&psm_service));
+	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 100, "Battery voltage state:", SwitchIdent_GetVoltageState());
 	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 150, "Battery charger type:", SwitchIdent_GetChargerType());
-	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 200, "Battery charging enabled:", SwitchIdent_IsChargingEnabled(&psm_service)? "Yes" : "No");
-	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 250, "Battery ample power supplied:", SwitchIdent_IsEnoughPowerSupplied(&psm_service)? "Yes" : "No");
+	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 200, "Battery charging enabled:", SwitchIdent_IsChargingEnabled()? "Yes" : "No");
+	Menu_DrawItem(450, 250 + ((MENU_Y_DIST - item_height) / 2) + 250, "Battery ample power supplied:", SwitchIdent_IsEnoughPowerSupplied()? "Yes" : "No");
 }
 
 static void Menu_Storage(void) {
@@ -139,9 +139,6 @@ void Menu_Main(void) {
 	if (R_FAILED(ret = smGetService(&setcal_service, "set:cal")))
 		printf("setcalInitialize() failed: 0x%x.\n\n", ret);
 
-	if (R_FAILED(ret = smGetService(&psm_service, "psm")))
-		printf("psmInitialize() failed: 0x%x.\n\n", ret);
-
 	if (R_FAILED(ret = smGetService(&wlaninf_service, "wlan:inf")))
 		printf("wlaninfInitialize() failed: 0x%x.\n\n", ret);
 
@@ -210,6 +207,5 @@ void Menu_Main(void) {
 	}
 
 	serviceClose(&wlaninf_service);
-	serviceClose(&psm_service);
 	serviceClose(&setcal_service);
 }


### PR DESCRIPTION
psm control API [was changed][1] in libnx 2.0.0

it will help to fix fatal crash in [Ams 0.8.2 + nx 2.0.0 environ][2]
for example hbmenu also has [similar patch][3]

[1]: https://github.com/switchbrew/libnx/commit/e59036d
[2]: https://github.com/Atmosphere-NX/Atmosphere/issues/309
[3]: https://github.com/switchbrew/nx-hbmenu/commit/1e3f057