### PR TITLE
adding more regions support for SwitchIdent_GetRegion(void)

### DIFF
--- a/common/system.c
+++ b/common/system.c
@@ -24,6 +24,9 @@ char *SwitchIdent_GetRegion(void) {
 		"USA",
 		"EUR",
 		"AUS",
+		"CHN",
+		"KOR",
+		"TWN",
 		"Unknown"
 	};
 
@@ -31,7 +34,7 @@ char *SwitchIdent_GetRegion(void) {
 
 	if (R_FAILED(ret = setGetRegionCode(&regionCode))) {
 		printf("setGetRegionCode() failed: 0x%x.\n\n", ret);
-		return regions[4];
+		return regions[7];
 	}
 
 	return regions[regionCode];


### PR DESCRIPTION
Region codes fetched from https://switchbrew.org/wiki/Settings_services#RegionCode .